### PR TITLE
add lock event support

### DIFF
--- a/VIEventTracker/VIETEvent.h
+++ b/VIEventTracker/VIETEvent.h
@@ -12,5 +12,6 @@
 
 @property (nonatomic) NSInteger count;
 @property (nonatomic, getter = isTracking) BOOL tracking;
+@property (nonatomic, getter = isLocked) BOOL locked;
 
 @end

--- a/VIEventTracker/VIETEvent.m
+++ b/VIEventTracker/VIETEvent.m
@@ -18,6 +18,7 @@
     if (self) {
         _tracking = YES;
         _count = 0;
+        _locked = NO;
     }
     
     return self;

--- a/VIEventTracker/VIEventTracker.h
+++ b/VIEventTracker/VIEventTracker.h
@@ -59,6 +59,26 @@
 + (void)resumeEvent:(NSString *)event;
 
 /**
+ *  Call this method will untrack the Event, that means the handler for the event will not be called until next launch or unlock event.
+ *  @code 
+ *  // Invoke this method will not call the handler block
+ *  + (void)trackEvent:(NSString *)event 
+ *             handler:(void(^)(NSUInteger count))handler;
+ *
+ *  @endcode
+ *
+ *  @param event Event name
+ */
++ (void)lockTrackEvent:(NSString *)event;
+
+/**
+ *  If event is lock then unlock event.
+ *
+ *  @param event Event name
+ */
++ (void)unlockEvent:(NSString *)event;
+
+/**
  *  Reset event to original state
  *
  *  @param event Event name

--- a/VIEventTracker/VIEventTracker.m
+++ b/VIEventTracker/VIEventTracker.m
@@ -53,7 +53,7 @@
         eventModel = [[VIETEvent alloc] init];
     }
     
-    if (eventModel.isTracking) {
+    if (eventModel.isTracking && !eventModel.isLocked) {
         eventModel.count += step;
         
         tracker.trackData[event] = eventModel;
@@ -102,6 +102,30 @@
         eventModel.tracking = YES;
         tracker.trackData[event] = eventModel;
     }
+}
+
++ (void)lockTrackEvent:(NSString *)event {
+    VIEventTracker *tracker = [VIEventTracker sharedTracker];
+    
+    VIETEvent *eventModel = tracker.trackData[event];
+    if (!eventModel) {
+        return;
+    }
+    
+    eventModel.locked = YES;
+    tracker.trackData[event] = eventModel;
+}
+
++ (void)unlockEvent:(NSString *)event {
+    VIEventTracker *tracker = [VIEventTracker sharedTracker];
+    
+    VIETEvent *eventModel = tracker.trackData[event];
+    if (!eventModel) {
+        return;
+    }
+    
+    eventModel.locked = NO;
+    tracker.trackData[event] = eventModel;
 }
 
 + (void)resetEvent:(NSString *)event {


### PR DESCRIPTION
lock event will untrack the Event, that means the handler for the event will not be called until next launch or unlock event.
